### PR TITLE
Fix HUD button not appearing with most recent version of ASET

### DIFF
--- a/Distribution/GameData/BDMk22/Props/HUDToggleSwitch.cfg
+++ b/Distribution/GameData/BDMk22/Props/HUDToggleSwitch.cfg
@@ -4,7 +4,7 @@ PROP
 	
 	MODEL
 	{
-		model = ASET/ASET_Props/Control/SwitchTumble/SwitchTumble
+		model = ASET/ASET_Props/Control/Switch_Tumble/SwitchTumble
 	}
   
 	MODULE
@@ -37,7 +37,7 @@ PROP
 		transformName = TextPlateTopObj
 		fontSize = 0.006
 		refreshRate = 150
-		labelText = [#<=0:333333;FF0000;FFFFFF=>]       ON $&$ CUSTOM_ALCOR_POWEROFF
+		labelText = ON $&$ CUSTOM_ALCOR_POWEROFF
 	}
 	
 	 MODULE
@@ -46,7 +46,7 @@ PROP
 		transformName = TextPlateBottomObj
 		fontSize = 0.006
 		refreshRate = 150
-		labelText = [#<=0:333333;FF0000;FFFFFF=>]       OFF $&$ CUSTOM_ALCOR_POWEROFF
+		labelText = OFF $&$ CUSTOM_ALCOR_POWEROFF
 	}
 	
 	MODULE


### PR DESCRIPTION
commit fixes the HUD switch not appearing with a fresh install of ASET and removes the coloration (handling change from RPM + insufficient documentation to correct)